### PR TITLE
Fix bug when answers are empty in dataset

### DIFF
--- a/train.py
+++ b/train.py
@@ -246,7 +246,7 @@ def get_dataset(args, datasets, data_dir, tokenizer, split_name):
     dataset_name=''
     for dataset in datasets:
         dataset_name += f'_{dataset}'
-        dataset_dict_curr = util.read_squad(f'{data_dir}/{dataset}')
+        dataset_dict_curr = util.read_squad(f'{data_dir}/{dataset}', test=split_name=='test')
         dataset_dict = util.merge(dataset_dict, dataset_dict_curr)
     data_encodings = read_and_process(args, tokenizer, dataset_dict, data_dir, dataset_name, split_name)
     return util.QADataset(data_encodings, train=(split_name=='train')), dataset_dict

--- a/util.py
+++ b/util.py
@@ -186,7 +186,7 @@ class QADataset(Dataset):
     def __len__(self):
         return len(self.encodings['input_ids'])
 
-def read_squad(path):
+def read_squad(path, test=False):
     path = Path(path)
     with open(path, 'rb') as f:
         squad_dict = json.load(f)
@@ -196,7 +196,9 @@ def read_squad(path):
             context = passage['context']
             for qa in passage['qas']:
                 question = qa['question']
-                for answer in  qa['answers']:
+                if test and len(qa['answers']) == 0:
+                    qa['answers'] = [{"answer_start": -1, "text": ""}]
+                for answer in qa['answers']:
                     data_dict['question'].append(question)
                     data_dict['context'].append(context)
                     data_dict['id'].append(qa['id'])


### PR DESCRIPTION
Currently evaluating on the test set with the below command raises an error.
`python train.py --do-eval --sub-file mtl_submission.csv --save-dir save/baseline-01`

**Main Cause**
`util.read_squad` appends an entry per answer in the list of answers found in the datasets.
i.e. `for answer in qa['answers']:`

When answers are empty lists (e.g. in oodomain_test datasets), this causes no entries to be appended and the resulting `data_dict` returned by `util.read_squad` is empty. The error is raised when we try to submit empty lists to the tokenizer.

**Solution**
This patch fixes that by checking if we are evaluating on a `test` split. If so, when we encounter an empty answer list, we set it as `[{"answer_start": -1, "text": ""}]`.